### PR TITLE
Remove support for PostgreSQL < 9.2

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -147,15 +147,6 @@ have_func("rb_hash_delete", "ruby.h")
 
 have_header("st.h")
 
-if version >= 74
-   if !have_header("server/utils/array.h")
-      if !have_header("utils/array.h")
-         raise "I cant't find server/utils/array.h"
-      end
-      $CFLAGS += " -DPG_UTILS_ARRAY"
-   end
-end
-
 if macro_defined?("PG_TRY", %Q{#include "c.h"\n#include "utils/elog.h"})
     $CFLAGS += " -DPG_PL_TRYCATCH"
 end

--- a/extconf.rb
+++ b/extconf.rb
@@ -35,9 +35,8 @@ rescue
    true
 end
 
-def create_lang(version = 74, suffix = '', safe = 0)
+def create_lang(suffix = '', safe = 0)
    language, opaque = 'c', 'language_handler'
-   opaque = "opaque" if version == 72
    safe = safe.to_i
    trusted = if safe >= 4
 		"trusted"
@@ -180,8 +179,6 @@ if enable_conversion
    end
 end
 
-$CFLAGS += " -DPG_PL_VERSION=#{version}"
-
 suffix = with_config('suffix').to_s
 $CFLAGS += " -DPLRUBY_CALL_HANDLER=plruby#{suffix}_call_handler"
 $CFLAGS += " -DPLRUBY_VALIDATOR=plruby#{suffix}_validator"
@@ -255,6 +252,6 @@ end
 
 make.close
 
-create_lang(version, suffix, safe)
+create_lang(suffix, safe)
 
 create_header('src/extconf.h')

--- a/src/conversions/convcommon.h
+++ b/src/conversions/convcommon.h
@@ -14,8 +14,6 @@
     pfree(p2_);					\
 } while (0)
 
-#if PG_PL_VERSION >= 74
-
 #define PL_MDUMP(name_,func_)                                   \
 static VALUE                                                    \
 name_(int argc, VALUE *argv, VALUE obj)                         \
@@ -76,14 +74,6 @@ name_(VALUE obj, VALUE a)                                               \
 
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
 extern VALUE plruby_s_load _((VALUE, VALUE));
-#endif
-
-#else
-
-#define PL_MDUMP(name_,func_)
-#define PL_MLOAD(name_,func_,type_) 
-#define PL_MLOADVAR(name_,func_,type_,size_)
-
 #endif
 
 extern VALUE plruby_to_s _((VALUE));

--- a/src/conversions/datetime/plruby_datetime.c
+++ b/src/conversions/datetime/plruby_datetime.c
@@ -90,8 +90,6 @@ pl_tint_s_datum(VALUE obj, VALUE a)
     return res;
 }
 
-#if PG_PL_VERSION >= 74
-	
 static VALUE
 pl_tint_mdump(int argc, VALUE *argv, VALUE obj)
 {
@@ -126,8 +124,6 @@ pl_tint_mload(VALUE obj, VALUE a)
     tint->high = RARRAY_PTR(a)[1];
     return obj;
 }
-
-#endif
     
 static VALUE
 pl_tint_init(VALUE obj, VALUE a, VALUE b)
@@ -253,13 +249,11 @@ void Init_plruby_datetime()
     rb_define_method(pl_cTinter, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cTinter, "initialize_copy", pl_tint_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cTinter, "marshal_load", pl_tint_mload, 1);
     rb_define_method(pl_cTinter, "marshal_dump", pl_tint_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cTinter, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cTinter, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cTinter, "low", pl_tint_low, 0);
     rb_define_method(pl_cTinter, "low=", pl_tint_lowset, 1);

--- a/src/conversions/geometry/plruby_geometry.c
+++ b/src/conversions/geometry/plruby_geometry.c
@@ -1334,8 +1334,6 @@ pl_path_concat(VALUE obj, VALUE a)
     return obj;
 }
 
-#if PG_PL_VERSION >= 75
-
 static VALUE
 pl_path_area(VALUE obj)
 {
@@ -1344,8 +1342,6 @@ pl_path_area(VALUE obj)
     Data_Get_Struct(obj, PATH, p0);
     RETURN_FLOAT(obj, PLRUBY_DFC1(path_area, p0));
 }
-
-#endif
 
 
 /* Extracted from geo_utils.c */
@@ -2220,13 +2216,11 @@ void Init_plruby_geometry()
     rb_define_method(pl_cPoint, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cPoint, "initialize_copy", pl_point_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cPoint, "marshal_load", pl_point_mload, 1);
     rb_define_method(pl_cPoint, "marshal_dump", pl_point_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cPoint, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cPoint, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cPoint, "x", pl_point_x, 0);
     rb_define_method(pl_cPoint, "x=", pl_point_setx, 1);
@@ -2267,13 +2261,11 @@ void Init_plruby_geometry()
     rb_define_method(pl_cLseg, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cLseg, "initialize_copy", pl_lseg_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cLseg, "marshal_load", pl_lseg_mload, 1);
     rb_define_method(pl_cLseg, "marshal_dump", pl_lseg_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cLseg, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cLseg, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cLseg, "[]", pl_lseg_aref, 1);
     rb_define_method(pl_cLseg, "[]=", pl_lseg_aset, 2);
@@ -2307,13 +2299,11 @@ void Init_plruby_geometry()
     rb_define_method(pl_cBox, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cBox, "initialize_copy", pl_box_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cBox, "marshal_load", pl_box_mload, 1);
     rb_define_method(pl_cBox, "marshal_dump", pl_box_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cBox, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cBox, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cBox, "low", pl_box_low, 0);
     rb_define_method(pl_cBox, "high", pl_box_high, 0);
@@ -2370,13 +2360,11 @@ void Init_plruby_geometry()
     rb_define_method(pl_cPath, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cPath, "initialize_copy", pl_path_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cPath, "marshal_load", pl_path_mload, 1);
     rb_define_method(pl_cPath, "marshal_dump", pl_path_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cPath, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cPath, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cPath, "to_s", pl_path_to_s, 0);
     rb_define_method(pl_cPath, "<=>", pl_path_cmp, 1);
@@ -2393,9 +2381,7 @@ void Init_plruby_geometry()
     rb_define_method(pl_cPath, "/", pl_path_div, 1);
     rb_define_method(pl_cPath, "to_poly", pl_path_to_poly, 0);
     rb_define_method(pl_cPath, "to_polygon", pl_path_to_poly, 0);
-#if PG_PL_VERSION >= 75
     rb_define_method(pl_cPath, "area", pl_path_area, 0);
-#endif
     pl_cPoly = rb_define_class("Polygon", rb_cObject);
     rb_undef_method(CLASS_OF(pl_cPoly), "method_missing");
 #if HAVE_RB_DEFINE_ALLOC_FUNC
@@ -2412,13 +2398,11 @@ void Init_plruby_geometry()
     rb_define_method(pl_cPoly, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cPoly, "initialize_copy", pl_poly_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cPoly, "marshal_load", pl_poly_mload, 1);
     rb_define_method(pl_cPoly, "marshal_dump", pl_poly_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cPoly, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cPoly, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cPoly, "to_s", pl_poly_to_s, 0);
     rb_define_method(pl_cPoly, "left?", pl_poly_left, 1);
@@ -2454,13 +2438,11 @@ void Init_plruby_geometry()
     rb_define_method(pl_cCircle, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cCircle, "initialize_copy", pl_circle_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cCircle, "marshal_load", pl_circle_mload, 1);
     rb_define_method(pl_cCircle, "marshal_dump", pl_circle_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cCircle, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cCircle, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cCircle, "to_s", pl_circle_to_s, 0);
     rb_define_method(pl_cCircle, "left?", pl_circle_left, 1);

--- a/src/conversions/network/plruby_network.c
+++ b/src/conversions/network/plruby_network.c
@@ -162,11 +162,7 @@ NAME_(VALUE obj)						\
 
 NETWORK_CALL(pl_inet_host, network_host);
 
-#if PG_PL_VERSION >= 82
 NETWORK_CALL(pl_inet_abbrev, inet_abbrev);
-#else
-NETWORK_CALL(pl_inet_abbrev, network_abbrev);
-#endif
 
 static VALUE
 pl_inet_to_s(VALUE obj)
@@ -210,8 +206,6 @@ pl_inet_setmasklen(VALUE obj, VALUE a)
     return res;
 }
 
-#if PG_PL_VERSION >= 74
-
 static VALUE
 pl_inet_family(VALUE obj)
 {
@@ -234,8 +228,6 @@ pl_inet_family(VALUE obj)
     return str;
 }
 
-#endif
-
 #define NETWORK_INET(NAME_, FUNCTION_)					\
 static VALUE								\
 NAME_(VALUE obj)							\
@@ -257,12 +249,7 @@ NAME_(VALUE obj)							\
 NETWORK_INET(pl_inet_broadcast, network_broadcast);
 NETWORK_INET(pl_inet_network, network_network);
 NETWORK_INET(pl_inet_netmask, network_netmask);
-
-#if PG_PL_VERSION >= 74
-
 NETWORK_INET(pl_inet_hostmask, network_hostmask);
-
-#endif
 
 static VALUE
 pl_inet_last(VALUE obj)
@@ -280,8 +267,6 @@ pl_inet_last(VALUE obj)
     if (OBJ_TAINTED(obj)) OBJ_TAINT(res);
     return res;
 }
-
-#if PG_PL_VERSION >= 75
 
 static VALUE
 pl_inet_s_caddr(VALUE obj)
@@ -328,9 +313,6 @@ pl_inet_s_sport(VALUE obj)
 {
     return INT2NUM(PLRUBY_DFC0(inet_server_port));
 }
-
-#endif
-    
 
 static void pl_mac_mark(macaddr *mac) {}
 
@@ -465,25 +447,21 @@ void Init_plruby_network()
     rb_define_singleton_method(pl_cInet, "new", plruby_s_new, -1);
     rb_define_singleton_method(pl_cInet, "from_string", plruby_s_new, -1);
     rb_define_singleton_method(pl_cInet, "from_datum", pl_inet_s_datum, 1);
-#if PG_PL_VERSION >= 75
     rb_define_singleton_method(pl_cInet, "client_addr", pl_inet_s_caddr, 0);
     rb_define_singleton_method(pl_cInet, "client_port", pl_inet_s_cport, 0);
     rb_define_singleton_method(pl_cInet, "server_addr", pl_inet_s_saddr, 0);
     rb_define_singleton_method(pl_cInet, "server_port", pl_inet_s_sport, 0);
-#endif
     rb_define_method(pl_cInet, "to_datum", pl_inet_to_datum, 1);
     rb_define_method(pl_cInet, "initialize", pl_inet_init, -1);
 #ifndef HAVE_RB_INITIALIZE_COPY
     rb_define_method(pl_cInet, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cInet, "initialize_copy", pl_inet_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cInet, "marshal_load", pl_inet_mload, 1);
     rb_define_method(pl_cInet, "marshal_dump", pl_inet_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cInet, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cInet, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cInet, "<=>", pl_inet_cmp, 1);
     rb_define_method(pl_cInet, "contained?", pl_inet_contained, 1);
@@ -494,15 +472,11 @@ void Init_plruby_network()
     rb_define_method(pl_cInet, "abbrev", pl_inet_abbrev, 0);
     rb_define_method(pl_cInet, "masklen", pl_inet_masklen, 0);
     rb_define_method(pl_cInet, "set_masklen", pl_inet_setmasklen, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cInet, "family", pl_inet_family, 0);
-#endif
     rb_define_method(pl_cInet, "broadcast", pl_inet_broadcast, 0);
     rb_define_method(pl_cInet, "network", pl_inet_network, 0);
     rb_define_method(pl_cInet, "netmask", pl_inet_netmask, 0);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cInet, "hostmask", pl_inet_hostmask, 0);
-#endif
     rb_define_method(pl_cInet, "to_s", pl_inet_to_s, 0);
     rb_define_method(pl_cInet, "first", pl_inet_network, 0);
     rb_define_method(pl_cInet, "last", pl_inet_last, 0);
@@ -523,13 +497,11 @@ void Init_plruby_network()
     rb_define_method(pl_cMac, "clone", plruby_clone, 0);
 #endif
     rb_define_method(pl_cMac, "initialize_copy", pl_mac_init_copy, 1);
-#if PG_PL_VERSION >= 74
     rb_define_method(pl_cMac, "marshal_load", pl_mac_mload, 1);
     rb_define_method(pl_cMac, "marshal_dump", pl_mac_mdump, -1);
 #ifndef RUBY_CAN_USE_MARSHAL_LOAD
     rb_define_singleton_method(pl_cMac, "_load", plruby_s_load, 1);
     rb_define_alias(pl_cMac, "_dump", "marshal_dump");
-#endif
 #endif
     rb_define_method(pl_cMac, "<=>", pl_mac_cmp, 1);
     rb_define_method(pl_cMac, "to_s", pl_mac_to_s, 0);

--- a/src/plruby.h
+++ b/src/plruby.h
@@ -27,16 +27,10 @@
 #include "utils/array.h"
 #include "utils/varlena.h"
 #include "utils/timestamp.h"
-
-#if PG_PL_VERSION >= 75
 #include "nodes/pg_list.h"
 #include "utils/typcache.h"
 #include "access/xact.h"
-#endif
-
-#if PG_PL_VERSION >= 81
 #include "utils/memutils.h"
-#endif
 
 #if PG_VERSION_NUM >= 90300
 #include "access/htup_details.h"
@@ -225,9 +219,7 @@ typedef struct pl_proc_desc
     bool	result_val;
     char	result_align;
     int		nargs;
-#if PG_PL_VERSION >= 75
     int         named_args;
-#endif
     FmgrInfo	arg_func[FUNC_MAX_ARGS];
     Oid		arg_elem[FUNC_MAX_ARGS];
     Oid		arg_type[FUNC_MAX_ARGS];

--- a/src/pltrans.c
+++ b/src/pltrans.c
@@ -1,7 +1,5 @@
 #include "plruby.h"
 
-#if PG_PL_VERSION >= 75
-
 #define PG_PL_READ_UNCOMMITTED 0
 #define PG_PL_READ_COMMITTED   1
 #define PG_PL_REPETABLE_READ   2
@@ -292,10 +290,6 @@ pl_transaction(VALUE obj)
     return Qnil;
 }
         
-#endif
-
-#if PG_PL_VERSION >= 81
-
 static VALUE
 pl_savepoint(VALUE obj, VALUE a)
 {
@@ -347,12 +341,9 @@ pl_rollback(VALUE obj, VALUE a)
     return Qnil;
 }
 
-#endif
-    
 void
 Init_plruby_trans()
 {
-#if PG_PL_VERSION >= 75
     VALUE pl_mPL;
 
     pl_mPL = rb_const_get(rb_cObject, rb_intern("PL"));
@@ -364,11 +355,9 @@ Init_plruby_trans()
     rb_define_global_const("REPETABLE_READ", INT2FIX(PG_PL_REPETABLE_READ));
     rb_define_global_const("SERIALIZABLE", INT2FIX(PG_PL_SERIALIZABLE));
     rb_define_global_function("transaction", pl_transaction, 0);
-#if PG_PL_VERSION >= 81
     rb_define_global_function("savepoint", pl_savepoint, 1);
     rb_define_global_function("release_savepoint", pl_release, 1);
     rb_define_global_function("rollback_to_savepoint", pl_rollback, 1);
-#endif
     pl_cTrans = rb_define_class_under(pl_mPL, "Transaction", rb_cObject);
 #if HAVE_RB_DEFINE_ALLOC_FUNC
     rb_undef_alloc_func(pl_cTrans);
@@ -379,5 +368,4 @@ Init_plruby_trans()
     rb_define_method(pl_cTrans, "commit", pl_commit, 0);
     rb_define_method(pl_cTrans, "abort", pl_abort, 0);
     rb_define_method(pl_cTrans, "rollback", pl_abort, 0);
-#endif
 }


### PR DESCRIPTION
Since we no longer support PostgreSQL versions before 9.2 we can remove
a lot of ifdefs. And when removing them it turns out we no longer need
PG_PL_VERSION since all remaining ifdefs use PG_VERSION_NUM.