### PR TITLE
Quick cleanup of the test runners

### DIFF
--- a/test/conv_bitstring/b.rb
+++ b/test/conv_bitstring/b.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 require 'rbconfig'
-include RbConfig
+
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
@@ -18,7 +18,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
+    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/conv_bitstring/b.rb
+++ b/test/conv_bitstring/b.rb
@@ -4,9 +4,6 @@ include RbConfig
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
-language, extension = 'c', '_new_trigger'
-opaque = 'language_handler'
-
 suffix = ARGV[0].to_s
 
 begin
@@ -20,9 +17,9 @@ begin
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF
  
-   create function plruby#{suffix}_call_handler() returns #{opaque}
+   create function plruby#{suffix}_call_handler() returns language_handler
     as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
-   language '#{language}';
+   language c;
  
    create trusted procedural language 'plruby#{suffix}'
         handler plruby#{suffix}_call_handler;

--- a/test/conv_bitstring/b.rb
+++ b/test/conv_bitstring/b.rb
@@ -16,16 +16,6 @@ begin
       f.print x
    end
    f.close
-   
-   Dir["test.expected.*.in"].each do |name|
-      result = name.sub(/\.in\z/, '')
-      f = File.new(result, "w")
-      IO.foreach(name) do |x|
-	 x.gsub!(/'plruby'/i, "'plruby#{suffix}'")
-	 f.print x
-      end
-      f.close
-   end
 
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF

--- a/test/conv_bitstring/b.rb
+++ b/test/conv_bitstring/b.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 require 'rbconfig'
 
-pwd = Dir.pwd
-pwd.sub!(%r{[^/]+/[^/]+$}, "")
+dir = File.expand_path('../..', Dir.pwd)
 
 suffix = ARGV[0].to_s
 
@@ -18,7 +17,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
+    as '#{dir}/src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/conv_bitstring/runtest
+++ b/test/conv_bitstring/runtest
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DBNAME=plruby_test
-export DBNAME
 
 echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME

--- a/test/conv_bitstring/runtest
+++ b/test/conv_bitstring/runtest
@@ -2,17 +2,13 @@
 
 DBNAME=plruby_test
 
-echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME
 
-echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
-echo "**** Create procedural language plruby$1 ****"
 "${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
-echo "**** Running test queries ****"
 psql -q -n -X -e $DBNAME < test_queries.sql > test.out 2>&1
 
 if cmp -s test.expected test.out; then
@@ -21,4 +17,3 @@ else
     echo "    Tests failed - look at diffs between"
     echo "    test.expected and test.out"
 fi
-

--- a/test/conv_geometry/b.rb
+++ b/test/conv_geometry/b.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 require 'rbconfig'
-include RbConfig
+
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
@@ -18,7 +18,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
+    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/conv_geometry/b.rb
+++ b/test/conv_geometry/b.rb
@@ -4,9 +4,6 @@ include RbConfig
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
-language, extension = 'c', '_new_trigger'
-opaque = 'language_handler'
-
 suffix = ARGV[0].to_s
 
 begin
@@ -20,9 +17,9 @@ begin
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF
  
-   create function plruby#{suffix}_call_handler() returns #{opaque}
+   create function plruby#{suffix}_call_handler() returns language_handler
     as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
-   language '#{language}';
+   language c;
  
    create trusted procedural language 'plruby#{suffix}'
         handler plruby#{suffix}_call_handler;

--- a/test/conv_geometry/b.rb
+++ b/test/conv_geometry/b.rb
@@ -16,16 +16,6 @@ begin
       f.print x
    end
    f.close
-   
-   Dir["test.expected.*.in"].each do |name|
-      result = name.sub(/\.in\z/, '')
-      f = File.new(result, "w")
-      IO.foreach(name) do |x|
-	 x.gsub!(/'plruby'/i, "'plruby#{suffix}'")
-	 f.print x
-      end
-      f.close
-   end
 
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF

--- a/test/conv_geometry/b.rb
+++ b/test/conv_geometry/b.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 require 'rbconfig'
 
-pwd = Dir.pwd
-pwd.sub!(%r{[^/]+/[^/]+$}, "")
+dir = File.expand_path('../..', Dir.pwd)
 
 suffix = ARGV[0].to_s
 
@@ -18,7 +17,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
+    as '#{dir}/src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/conv_geometry/runtest
+++ b/test/conv_geometry/runtest
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DBNAME=plruby_test
-export DBNAME
 
 echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME

--- a/test/conv_geometry/runtest
+++ b/test/conv_geometry/runtest
@@ -2,17 +2,13 @@
 
 DBNAME=plruby_test
 
-echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME
 
-echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
-echo "**** Create procedural language plruby$1 ****"
 "${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
-echo "**** Running test queries ****"
 psql -q -n -X -e $DBNAME < test_queries.sql > test.out 2>&1
 
 if cmp -s test.expected test.out; then
@@ -21,4 +17,3 @@ else
     echo "    Tests failed - look at diffs between"
     echo "    test.expected and test.out"
 fi
-

--- a/test/conv_network/b.rb
+++ b/test/conv_network/b.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 require 'rbconfig'
-include RbConfig
+
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
@@ -18,7 +18,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
+    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/conv_network/b.rb
+++ b/test/conv_network/b.rb
@@ -4,9 +4,6 @@ include RbConfig
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
-language, extension = 'c', '_new_trigger'
-opaque = 'language_handler'
-
 suffix = ARGV[0].to_s
 
 begin
@@ -20,9 +17,9 @@ begin
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF
  
-   create function plruby#{suffix}_call_handler() returns #{opaque}
+   create function plruby#{suffix}_call_handler() returns language_handler
     as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
-   language '#{language}';
+   language c;
  
    create trusted procedural language 'plruby#{suffix}'
         handler plruby#{suffix}_call_handler;

--- a/test/conv_network/b.rb
+++ b/test/conv_network/b.rb
@@ -16,16 +16,6 @@ begin
       f.print x
    end
    f.close
-   
-   Dir["test.expected.*.in"].each do |name|
-      result = name.sub(/\.in\z/, '')
-      f = File.new(result, "w")
-      IO.foreach(name) do |x|
-	 x.gsub!(/'plruby'/i, "'plruby#{suffix}'")
-	 f.print x
-      end
-      f.close
-   end
 
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF

--- a/test/conv_network/b.rb
+++ b/test/conv_network/b.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 require 'rbconfig'
 
-pwd = Dir.pwd
-pwd.sub!(%r{[^/]+/[^/]+$}, "")
+dir = File.expand_path('../..', Dir.pwd)
 
 suffix = ARGV[0].to_s
 
@@ -18,7 +17,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
+    as '#{dir}/src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/conv_network/b.rb
+++ b/test/conv_network/b.rb
@@ -7,8 +7,7 @@ pwd.sub!(%r{[^/]+/[^/]+$}, "")
 language, extension = 'c', '_new_trigger'
 opaque = 'language_handler'
 
-version = ARGV[0].to_i
-suffix = ARGV[1].to_s
+suffix = ARGV[0].to_s
 
 begin
    f = File.new("test_queries.sql", "w")

--- a/test/conv_network/runtest
+++ b/test/conv_network/runtest
@@ -2,17 +2,13 @@
 
 DBNAME=plruby_test
 
-echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME
 
-echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
-echo "**** Create procedural language plruby$2 ****"
 "${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
-echo "**** Running test queries ****"
 psql -q -n -X -e $DBNAME < test_queries.sql > test.out 2>&1
 
 if cmp -s test.expected test.out; then
@@ -21,4 +17,3 @@ else
     echo "    Tests failed - look at diffs between"
     echo "    test.expected and test.out"
 fi
-

--- a/test/conv_network/runtest
+++ b/test/conv_network/runtest
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DBNAME=plruby_test
-export DBNAME
 
 echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME

--- a/test/conv_network/runtest
+++ b/test/conv_network/runtest
@@ -10,7 +10,7 @@ echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
 echo "**** Create procedural language plruby$2 ****"
-"${RUBY-ruby}" b.rb $*
+"${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
 echo "**** Running test queries ****"
@@ -20,6 +20,6 @@ if cmp -s test.expected test.out; then
     echo "    Tests passed O.K."
 else
     echo "    Tests failed - look at diffs between"
-    echo "    test.expected.$1 and test.out"
+    echo "    test.expected and test.out"
 fi
 

--- a/test/plp/b.rb
+++ b/test/plp/b.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 require 'rbconfig'
-include RbConfig
+
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
@@ -18,7 +18,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
+    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/plp/b.rb
+++ b/test/plp/b.rb
@@ -4,9 +4,6 @@ include RbConfig
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
-language, extension = 'c', '_new_trigger'
-opaque = 'language_handler'
-
 suffix = ARGV[0].to_s
 
 begin
@@ -16,12 +13,13 @@ begin
       f.print x
    end
    f.close
+
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF
  
-   create function plruby#{suffix}_call_handler() returns #{opaque}
+   create function plruby#{suffix}_call_handler() returns language_handler
     as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
-   language '#{language}';
+   language c;
  
    create trusted procedural language 'plruby#{suffix}'
         handler plruby#{suffix}_call_handler;

--- a/test/plp/b.rb
+++ b/test/plp/b.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 require 'rbconfig'
 
-pwd = Dir.pwd
-pwd.sub!(%r{[^/]+/[^/]+$}, "")
+dir = File.expand_path('../..', Dir.pwd)
 
 suffix = ARGV[0].to_s
 
@@ -18,7 +17,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
+    as '#{dir}/src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/plp/runtest
+++ b/test/plp/runtest
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DBNAME=plruby_test
-export DBNAME
 
 echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME

--- a/test/plp/runtest
+++ b/test/plp/runtest
@@ -2,20 +2,15 @@
 
 DBNAME=plruby_test
 
-echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME
 
-echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
-echo "**** Create procedural language plruby$1 ****"
 "${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
-echo "**** Create tables, functions and triggers ****"
 psql -q -n -X $DBNAME < test_setup.sql
 
-echo "**** Running test queries ****"
 psql -q -n -X -e $DBNAME < test_queries.sql > test.out 2>&1
 
 if cmp -s test.expected test.out; then
@@ -24,4 +19,3 @@ else
     echo "    Tests failed - look at diffs between"
     echo "    test.expected and test.out"
 fi
-

--- a/test/plt/b.rb
+++ b/test/plt/b.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 require 'rbconfig'
-include RbConfig
+
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
@@ -18,7 +18,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
+    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/plt/b.rb
+++ b/test/plt/b.rb
@@ -4,9 +4,6 @@ include RbConfig
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
-language, extension = 'c', '_new_trigger'
-opaque = 'language_handler'
-
 suffix = ARGV[0].to_s
 
 begin
@@ -16,12 +13,13 @@ begin
       f.print x
    end
    f.close
+
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF
  
-   create function plruby#{suffix}_call_handler() returns #{opaque}
+   create function plruby#{suffix}_call_handler() returns language_handler
     as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
-   language '#{language}';
+   language c;
  
    create trusted procedural language 'plruby#{suffix}'
         handler plruby#{suffix}_call_handler;

--- a/test/plt/b.rb
+++ b/test/plt/b.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 require 'rbconfig'
 
-pwd = Dir.pwd
-pwd.sub!(%r{[^/]+/[^/]+$}, "")
+dir = File.expand_path('../..', Dir.pwd)
 
 suffix = ARGV[0].to_s
 
@@ -18,7 +17,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
+    as '#{dir}/src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/plt/runtest
+++ b/test/plt/runtest
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DBNAME=plruby_test
-export DBNAME
 
 echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME

--- a/test/plt/runtest
+++ b/test/plt/runtest
@@ -2,20 +2,15 @@
 
 DBNAME=plruby_test
 
-echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME
 
-echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
-echo "**** Create procedural language plruby$1 ****"
 "${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
-echo "**** Create tables, functions and triggers ****"
 psql -q -n -X $DBNAME < test_setup.sql
 
-echo "**** Running test queries ****"
 psql -q -n -X -e $DBNAME < test_queries.sql > test.out 2>&1
 
 if cmp -s test.expected test.out; then
@@ -24,4 +19,3 @@ else
     echo "    Tests failed - look at diffs between"
     echo "    test.expected and test.out"
 fi
-

--- a/test/range/b.rb
+++ b/test/range/b.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 require 'rbconfig'
-include RbConfig
+
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
@@ -18,7 +18,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
+    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/range/b.rb
+++ b/test/range/b.rb
@@ -4,9 +4,6 @@ include RbConfig
 pwd = Dir.pwd
 pwd.sub!(%r{[^/]+/[^/]+$}, "")
 
-language, extension = 'c', '_new_trigger'
-opaque = 'language_handler'
-
 suffix = ARGV[0].to_s
 
 begin
@@ -20,9 +17,9 @@ begin
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF
  
-   create function plruby#{suffix}_call_handler() returns #{opaque}
+   create function plruby#{suffix}_call_handler() returns language_handler
     as '#{pwd}src/plruby#{suffix}.#{CONFIG["DLEXT"]}'
-   language '#{language}';
+   language c;
  
    create trusted procedural language 'plruby#{suffix}'
         handler plruby#{suffix}_call_handler;

--- a/test/range/b.rb
+++ b/test/range/b.rb
@@ -16,16 +16,6 @@ begin
       f.print x
    end
    f.close
-   
-   Dir["test.expected.*.in"].each do |name|
-      result = name.sub(/\.in\z/, '')
-      f = File.new(result, "w")
-      IO.foreach(name) do |x|
-	 x.gsub!(/'plruby'/i, "'plruby#{suffix}'")
-	 f.print x
-      end
-      f.close
-   end
 
    f = File.new("test_mklang.sql", "w")
    f.print <<EOF

--- a/test/range/b.rb
+++ b/test/range/b.rb
@@ -1,8 +1,7 @@
 #!/usr/bin/ruby
 require 'rbconfig'
 
-pwd = Dir.pwd
-pwd.sub!(%r{[^/]+/[^/]+$}, "")
+dir = File.expand_path('../..', Dir.pwd)
 
 suffix = ARGV[0].to_s
 
@@ -18,7 +17,7 @@ begin
    f.print <<EOF
  
    create function plruby#{suffix}_call_handler() returns language_handler
-    as '#{pwd}src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
+    as '#{dir}/src/plruby#{suffix}.#{RbConfig::CONFIG["DLEXT"]}'
    language c;
  
    create trusted procedural language 'plruby#{suffix}'

--- a/test/range/runtest
+++ b/test/range/runtest
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DBNAME=plruby_test
-export DBNAME
 
 echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME

--- a/test/range/runtest
+++ b/test/range/runtest
@@ -2,17 +2,13 @@
 
 DBNAME=plruby_test
 
-echo "**** Destroy old database $DBNAME ****"
 dropdb $DBNAME
 
-echo "**** Create test database $DBNAME ****"
 createdb $DBNAME
 
-echo "**** Create procedural language plruby$1 ****"
 "${RUBY-ruby}" b.rb "$1"
 psql -q -n -X $DBNAME < test_mklang.sql
 
-echo "**** Running test queries ****"
 psql -q -n -X -e $DBNAME < test_queries.sql > test.out 2>&1
 
 if cmp -s test.expected test.out; then
@@ -21,4 +17,3 @@ else
     echo "    Tests failed - look at diffs between"
     echo "    test.expected and test.out"
 fi
-


### PR DESCRIPTION
I decided to remove a lot of dead and needlessly convoluted code from the test runners to make them easier to read. I realize that this code is likely to be removed soon in favor of a more sane test framework (e.g. based on `pg_regress`), but I thought that it still might be useful to remove a lot of cruft first.

I think after this I am mostly satisfied until someone e.g. moves the project to `pg_regress` as part of making PL/Ruby more like other extensions.