### PR TITLE
Simplify version check

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -115,19 +115,10 @@ if ! have_header("catalog/pg_proc.h")
 end
 
 case version_str = `#{pg_config} --version`.strip
-when /^PostgreSQL (\d+).(\d+)/
-   if $1.to_i < 10
-       version = 10 * $1.to_i + $2.to_i
-   else
-       # In v10+, the second number means "minor" version - which is
-       # expected to be >= 10 one day.  So rather mutiply by 100 to avoid
-       # overflow.
-       version = 100 * $1.to_i + $2.to_i
-   end
-else
-   version = 0
+when /^PostgreSQL (\d+(:?\.\d+)?(:?\.\d+)?)/
+   version = $1.split('.').map(&:to_i)
 end
-if version < 92
+if !version || (version <=> [9, 2]) < 0
    raise <<-EOT
 
 ============================================================

--- a/extconf.rb
+++ b/extconf.rb
@@ -121,9 +121,11 @@ end
 if !version || (version <=> [9, 2]) < 0
    raise <<-EOT
 
-============================================================
-#{version_str} is not supported.  Try plruby-0.5.7 or older.
-============================================================
+ ==============================================================
+ #{version_str} is not supported.
+
+ Minimum supported version is 9.2.  Try plruby-0.5.7 or older.
+ ==============================================================
    EOT
 end
 


### PR DESCRIPTION
The parsing of PostgreSQL versions was unnecessarily complicated, especially since we do not use the parsed value anymore other than for the version check itself. While touching this code I also added support for versions like `12devel` and improved the error message.

To be honest I am not sure if the version check really is necessary to keep, but if it should be kept it should at least be simple.