### PR TITLE
FIx some compiler warnings

### DIFF
--- a/src/conversions/basic/conversions.h
+++ b/src/conversions/basic/conversions.h
@@ -1,5 +1,5 @@
 {
-    extern void plruby_require(char *);
+    extern void plruby_require(const char *);
 
     plruby_require("plruby/plruby_basic");
     rb_hash_aset(plruby_classes, INT2NUM(OIDOID), rb_cInteger);

--- a/src/plpl.c
+++ b/src/plpl.c
@@ -14,7 +14,7 @@ static ID id_delete;
 
 #endif
 
-static char *names = 
+static const char *names =
 "SELECT a.attname FROM pg_class c, pg_attribute a, pg_namespace n"
 " WHERE c.relname = '%s' AND a.attnum > 0 AND NOT a.attisdropped AND a.attrelid = c.oid"
 " AND c.relnamespace = n.oid AND n.nspname = '%s'"
@@ -53,7 +53,7 @@ pl_column_name(VALUE obj, VALUE table)
     return res;
 }
 
-static char *types = 
+static const char *types =
 "SELECT t.typname FROM pg_class c, pg_attribute a, pg_type t, pg_namespace n"
 " WHERE c.relname = '%s' and a.attnum > 0 AND NOT a.attisdropped"
 " AND a.attrelid = c.oid and a.atttypid = t.oid"
@@ -120,7 +120,7 @@ pl_query_name(VALUE obj)
 {
     VALUE res, tmp;
     struct pl_tuple *tpl;
-    char * attname;
+    const char * attname;
     int i;
 
     tmp = rb_thread_local_aref(rb_thread_current(), id_thr);

--- a/src/plplan.c
+++ b/src/plplan.c
@@ -48,7 +48,7 @@ pl_plan_save(VALUE obj)
 
     if (qdesc->plan == NULL) {
         char buf[128];
-        char *reason;
+        const char *reason;
             
         switch (SPI_result) {
         case SPI_ERROR_ARGUMENT:
@@ -209,7 +209,7 @@ pl_plan_init(int argc, VALUE *argv, VALUE obj)
 
     if (plan == NULL) {
         char            buf[128];
-        char       *reason;
+        const char      *reason;
 
         switch (SPI_result) {
         case SPI_ERROR_ARGUMENT:

--- a/src/plruby.c
+++ b/src/plruby.c
@@ -127,7 +127,7 @@ protect_require(VALUE name)
 }
 
 static void
-plruby_require(char *name)
+plruby_require(const char *name)
 {
     int status;
 
@@ -226,7 +226,7 @@ pl_conversions_missing(int argc, VALUE *argv, VALUE obj)
 }
 
 VALUE
-plruby_define_void_class(char *name, char *path)
+plruby_define_void_class(const char *name, const char *path)
 {
     VALUE klass;
 
@@ -713,7 +713,7 @@ PLRUBY_CALL_HANDLER(PG_FUNCTION_ARGS)
     return pl_internal_call_handler(&plth);
 }
 
-static char *definition = "def PLtemp.%s(%s)\n%s\nend";
+static const char *definition = "def PLtemp.%s(%s)\n%s\nend";
 
 static VALUE
 pl_arg_names(HeapTuple procTup, pl_proc_desc *prodesc) 
@@ -768,7 +768,7 @@ pl_compile(struct pl_thread_st *plth, int istrigger)
     VALUE value_proname;
     Oid result_oid = 0, arg_type[FUNC_MAX_ARGS];
     int nargs = 0;
-    static char *argt = "new, old, args, tg";
+    static const char *argt = "new, old, args, tg";
     PG_FUNCTION_ARGS;
     
     fcinfo = plth->fcinfo;
@@ -1377,15 +1377,15 @@ pl_exist_singleton()
     return 1;
 }
 
-static char *recherche = 
+static const char *recherche =
     "select name, args, body from plruby_singleton_methods where name = '%s'";
 
-static char *singleton = "select prosrc from pg_proc,pg_language,pg_type"
+static const char *singleton = "select prosrc from pg_proc,pg_language,pg_type"
 " where proname = '%s' and pg_proc.prolang = pg_language.oid"
 " and pg_language.lanname = 'plruby'"
 " and prorettype = pg_type.oid and typname != 'trigger'";
 
-static char *def_singleton = "def PLtemp.%s(*args)\n%s\nend";
+static const char *def_singleton = "def PLtemp.%s(*args)\n%s\nend";
 
 #ifndef HAVE_RB_BLOCK_CALL
 static VALUE

--- a/src/plruby.c
+++ b/src/plruby.c
@@ -333,7 +333,7 @@ pl_init_conversions()
 #endif
 }
 
-static void pl_result_mark(VALUE obj) {}
+static void pl_result_mark(void *ptr) {}
 
 static VALUE
 pl_protect(plth)

--- a/src/plruby.c
+++ b/src/plruby.c
@@ -1094,6 +1094,7 @@ for_numvals(obj, argobj)
     Form_pg_type fpg;
     VALUE key, value;
     struct foreach_fmgr *arg;
+    Form_pg_attribute attr;
 
     Data_Get_Struct(argobj, struct foreach_fmgr, arg);
     key = plruby_to_s(rb_ary_entry(obj, 0));
@@ -1107,7 +1108,7 @@ for_numvals(obj, argobj)
     }
     attnum -= 1;
 
-    Form_pg_attribute attr = TupleDescAttr(arg->tupdesc, attnum);
+    attr = TupleDescAttr(arg->tupdesc, attnum);
     if (attr->attisdropped) {
         return Qnil;
     }

--- a/src/plruby.c
+++ b/src/plruby.c
@@ -162,6 +162,11 @@ static VALUE class_to_load = Qnil;
 static VALUE exec_th = Qnil;
 
 static VALUE
+pl_intern_require(VALUE fname) {
+    return rb_require((char *)fname);
+}
+
+static VALUE
 pl_require_th(VALUE th)
 {
     while (1) {
@@ -170,7 +175,7 @@ pl_require_th(VALUE th)
             if (TYPE(file_to_load) == T_STRING && 
                 RSTRING_PTR(file_to_load)) {
                 rb_undef_method(CLASS_OF(class_to_load), "method_missing");
-                rb_protect((VALUE(*)(VALUE))rb_require, 
+                rb_protect(pl_intern_require,
                            (VALUE)RSTRING_PTR(file_to_load), 0);
                 file_to_load = Qnil;
             }

--- a/src/plruby.h
+++ b/src/plruby.h
@@ -310,7 +310,7 @@ extern VALUE plruby_classes, plruby_conversions;
 extern Oid plruby_datum_oid _((VALUE, int *));
 extern VALUE plruby_datum_set _((VALUE, Datum));
 extern Datum plruby_datum_get _((VALUE, Oid *));
-extern VALUE plruby_define_void_class _((char *, char *));
+extern VALUE plruby_define_void_class _((const char *, const char *));
 #endif
 
 #define DFC1(a_, b_) DirectFunctionCall1((a_), (b_))

--- a/src/pltrans.c
+++ b/src/pltrans.c
@@ -39,7 +39,7 @@ pl_trans_mark(void *trans)
 #define make_savepoint_name(name) (name)
 #else
 static List *
-make_savepoint_name(char *name)
+make_savepoint_name(const char *name)
 {
     DefElem *f = makeNode(DefElem);
     f->defname = "savepoint_name";


### PR DESCRIPTION
When compiling I get a bunch of warnings and this merge request fixes most of them.

One it does not fix is false positives from -Wclobbered but there I am not sure why it is enabled in the first place, and what best practices say about disabling that kind of warning.